### PR TITLE
Separator references in the rules are incorrect

### DIFF
--- a/draft-rankin-ccsv.md
+++ b/draft-rankin-ccsv.md
@@ -53,14 +53,14 @@ A CCSV (Control-Character-Separated Values file) is a file format that enables m
 
 In order for a file to be a CCSV, it MUST adhere to the following formatting rules:
 
-1. A Record Separator (RS - ASCII entity %x1F) is used between each record in the file including the header.
-1. A Unit Separator (US - ASCII entity %x1E) is used between each field in a record.
-1. A CCSV MUST begin with a header.  The header consists of the names of the columns separated with (US) entities.
-1. The header is terminated with the (RS) entity if the document contains any records.
-1. The header and each record MUST contain the same number of (US) entities i.e., the header and each record MUST have the same number of fields.
-1. Each record in the body is delimited with a (RS) entity.  Note that carriage returns and line feeds are not part of the delimiter and are valid characters in the body of a field.
-1. Each field within a record is delimited with the (US) entity.
-1. The (US) entity and the (RS) separator MUST NOT appear in the body of a field.
+1. A Record Separator RS (U+001E) is used between each record in the file including the header.
+1. A Unit Separator US (U+001F) is used between each field in a record.
+1. A CCSV MUST begin with a header.  The header consists of the names of the columns separated with US (U+001F) entities.
+1. The header is terminated with the RS (U+001E) entity if the document contains any records.
+1. The header and each record MUST contain the same number of US (U+001F) entities i.e., the header and each record MUST have the same number of fields.
+1. Each record in the body is delimited with a RS (U+001E) entity.  Note that carriage returns and line feeds are not part of the delimiter and are valid characters in the body of a field.
+1. Each field within a record is delimited with the US (U+001F) entity.
+1. The US (U+001F) entity and the RS (U+001E) separator MUST NOT appear in the body of a field.
 
 
 The ABNF grammar {{!STD68}} appears as follows:


### PR DESCRIPTION
Correcting the separator references and updating the syntax to us the U+0000 format.